### PR TITLE
Specify maven-surefire-plugin version for code point, java lambda, an…

### DIFF
--- a/code-point-kata-solutions/pom.xml
+++ b/code-point-kata-solutions/pom.xml
@@ -68,4 +68,17 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <argLine>--enable-preview</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/java-lambda-kata-solutions/pom.xml
+++ b/java-lambda-kata-solutions/pom.xml
@@ -69,4 +69,16 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <argLine>--enable-preview</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/kata-of-katas-solutions/pom.xml
+++ b/kata-of-katas-solutions/pom.xml
@@ -67,4 +67,17 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <argLine>--enable-preview</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
…d kata of katas solutions modules to fix tests not being included in build.

Signed-off-by: Rinat Gatyatullin <rinattalgatovich.gatyatullin@bnymellon.com>

When I was looking into Java 17 work for the katas, I noticed in the build https://github.com/BNYMellon/CodeKatas/runs/2845553343 that tests for the code-point, java-lambda, and kata-of-katas solutions modules aren't actually being picked up and run. They say 0 of 0 tests run for those modules.

The issue seems to be related to the maven-surefire-plugin where those modules are using version 2.12.4 while the modules that do have tests picked up are using version 2.22.2.