### PR TITLE
Specify maven-surefire-plugin version for non-solutions kata modules.

### DIFF
--- a/calendar-kata/pom.xml
+++ b/calendar-kata/pom.xml
@@ -77,4 +77,16 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <argLine>--enable-preview</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/code-point-kata/pom.xml
+++ b/code-point-kata/pom.xml
@@ -68,4 +68,17 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <argLine>--enable-preview</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/deck-of-cards-kata/pom.xml
+++ b/deck-of-cards-kata/pom.xml
@@ -104,6 +104,14 @@
                     </compilerArgs>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <argLine>--enable-preview</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/donut-kata/pom.xml
+++ b/donut-kata/pom.xml
@@ -148,6 +148,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <argLine>--enable-preview</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/java-lambda-kata/pom.xml
+++ b/java-lambda-kata/pom.xml
@@ -69,4 +69,17 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <argLine>--enable-preview</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/jmh-kata/pom.xml
+++ b/jmh-kata/pom.xml
@@ -86,6 +86,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <argLine>--enable-preview</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/kata-of-katas/pom.xml
+++ b/kata-of-katas/pom.xml
@@ -67,4 +67,17 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <argLine>--enable-preview</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Signed-off-by: Rinat Gatyatullin <rinattalgatovich.gatyatullin@bnymellon.com>

This is related to #55. The non-solutions modules have a similar problem that the solutions modules had. If you run `mvn verify` or `mvn test` from either the root of the katas or from one of the kata modules you will notice that the build passes when it should fail with test failures.

That's because the tests aren't getting picked up, so people taking the katas won't be able to test their changes using the maven build and would have to rely on their IDE. Specifying the surefire plugin version fixes this and lets you run the kata tests from the maven build as expected.