### PR TITLE
Switch to using oracle-actions to download JDK from jdk.java.net.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -24,17 +24,12 @@ jobs:
     steps:
       - name: Git Checkout
         uses: actions/checkout@v2
-      - name: Download JDK ${{ matrix.java-version }}
-        uses: sormuras/download-jdk@v1
+      - name: Set JDK ${{ matrix.java-version }} from jdk.java.net
+        uses: oracle-actions/setup-java@v1
         id: download-jdk
         with:
-          feature: ${{ matrix.java-version }}
-      - name: Set JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v2
-        with:
-          java-version: ${{ steps.download-jdk.outputs.version }}
-          distribution: jdkfile
-          jdkFile: ${{ steps.download-jdk.outputs.file }}
+          website: jdk.java.net
+          release: ${{ matrix.java-version }}
       - name: JDK Version
         run: java --version
       - name: Enable Maven Cache

--- a/.github/workflows/solutions.yml
+++ b/.github/workflows/solutions.yml
@@ -24,17 +24,12 @@ jobs:
     steps:
       - name: Git Checkout
         uses: actions/checkout@v2
-      - name: Download JDK ${{ matrix.java-version }}
-        uses: sormuras/download-jdk@v1
+      - name: Set JDK ${{ matrix.java-version }} from jdk.java.net
+        uses: oracle-actions/setup-java@v1
         id: download-jdk
         with:
-          feature: ${{ matrix.java-version }}
-      - name: Set JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v2
-        with:
-          java-version: ${{ steps.download-jdk.outputs.version }}
-          distribution: jdkfile
-          jdkFile: ${{ steps.download-jdk.outputs.file }}
+          website: jdk.java.net
+          release: ${{ matrix.java-version }}
       - name: JDK Version
         run: java --version
       - name: Enable Maven Cache


### PR DESCRIPTION
Signed-off-by: Rinat Gatyatullin <rinattalgatovich.gatyatullin.@bnymellon.com>

Switching to oracle-actions/setup-java based on the conversation on this issue: https://github.com/sormuras/download-jdk/issues/25