### PR TITLE
Upgrade vulnerable dependencies

### DIFF
--- a/donut-kata-solutions/pom.xml
+++ b/donut-kata-solutions/pom.xml
@@ -42,6 +42,16 @@
         <junit5.version>5.10.1</junit5.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.14.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <dependency>
@@ -74,6 +84,12 @@
             <artifactId>junit-jupiter</artifactId>
             <version>${junit5.version}</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.14.0</version>
         </dependency>
 
         <dependency>

--- a/donut-kata/pom.xml
+++ b/donut-kata/pom.xml
@@ -43,6 +43,16 @@
         <junit5.version>5.10.1</junit5.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.14.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <dependency>


### PR DESCRIPTION
issue: `kotlin-maven-plugin` relies on a vulnerable version of `commons-io`

This change mitigates this issue by forcing a safe version of `commons-io` in the [dependency management](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html) section of the pom, which will precedent over the existing, vulnerable version `kotlin-maven-plugin` was using. Intellij's vulnerable dependency tool now shows there are **zero** vulnerable dependencies for this project.